### PR TITLE
Add board identifier encoding/decoding

### DIFF
--- a/src/bridge/__tests__/board-identifier.test.ts
+++ b/src/bridge/__tests__/board-identifier.test.ts
@@ -1,0 +1,299 @@
+import { describe, it, expect } from 'vitest';
+import {
+  cardId,
+  cardFromId,
+  dealerForBoard,
+  vulnerabilityForBoard,
+  encodeDeal,
+  decodeDeal,
+  encodeBoardIdentifier,
+  decodeBoardIdentifier,
+  formatCall,
+  parseCall,
+  formatCalls,
+  parseCalls,
+} from '../board-identifier';
+import { MOCK_DEAL } from '../mock';
+import type { Call, Card } from '../types';
+
+describe('cardId', () => {
+  it('returns 0 for 2 of clubs', () => {
+    expect(cardId({ suit: 'C', rank: '2' })).toBe(0);
+  });
+
+  it('returns 12 for ace of clubs', () => {
+    expect(cardId({ suit: 'C', rank: 'A' })).toBe(12);
+  });
+
+  it('returns 13 for 2 of diamonds', () => {
+    expect(cardId({ suit: 'D', rank: '2' })).toBe(13);
+  });
+
+  it('returns 51 for ace of spades', () => {
+    expect(cardId({ suit: 'S', rank: 'A' })).toBe(51);
+  });
+
+  it('returns 39 for 2 of spades', () => {
+    expect(cardId({ suit: 'S', rank: '2' })).toBe(39);
+  });
+
+  it('returns 8 for ten of clubs', () => {
+    expect(cardId({ suit: 'C', rank: 'T' })).toBe(8);
+  });
+});
+
+describe('cardFromId', () => {
+  it('returns 2 of clubs for 0', () => {
+    expect(cardFromId(0)).toEqual({ suit: 'C', rank: '2' });
+  });
+
+  it('returns ace of spades for 51', () => {
+    expect(cardFromId(51)).toEqual({ suit: 'S', rank: 'A' });
+  });
+
+  it('round-trips with cardId for all 52 cards', () => {
+    for (let id = 0; id < 52; id++) {
+      const card = cardFromId(id);
+      expect(cardId(card)).toBe(id);
+    }
+  });
+});
+
+describe('dealerForBoard', () => {
+  it('maps board numbers 1-16 to correct dealers', () => {
+    const expected: Record<number, string> = {
+      1: 'N', 2: 'E', 3: 'S', 4: 'W',
+      5: 'N', 6: 'E', 7: 'S', 8: 'W',
+      9: 'N', 10: 'E', 11: 'S', 12: 'W',
+      13: 'N', 14: 'E', 15: 'S', 16: 'W',
+    };
+    for (const [board, dealer] of Object.entries(expected)) {
+      expect(dealerForBoard(Number(board))).toBe(dealer);
+    }
+  });
+});
+
+describe('vulnerabilityForBoard', () => {
+  it('maps board numbers to correct vulnerabilities', () => {
+    const expected: Record<number, string> = {
+      1: 'None', 2: 'NS', 3: 'EW', 4: 'Both',
+      5: 'NS', 6: 'EW', 7: 'Both', 8: 'None',
+      9: 'EW', 10: 'Both', 11: 'None', 12: 'NS',
+      13: 'Both', 14: 'None', 15: 'NS', 16: 'EW',
+    };
+    for (const [board, vul] of Object.entries(expected)) {
+      expect(vulnerabilityForBoard(Number(board))).toBe(vul);
+    }
+  });
+});
+
+describe('formatCall', () => {
+  it('formats pass', () => {
+    expect(formatCall({ type: 'pass' })).toBe('P');
+  });
+
+  it('formats double', () => {
+    expect(formatCall({ type: 'double' })).toBe('X');
+  });
+
+  it('formats redouble', () => {
+    expect(formatCall({ type: 'redouble' })).toBe('XX');
+  });
+
+  it('formats bids', () => {
+    expect(formatCall({ type: 'bid', level: 1, strain: 'C' })).toBe('1C');
+    expect(formatCall({ type: 'bid', level: 3, strain: 'N' })).toBe('3N');
+    expect(formatCall({ type: 'bid', level: 7, strain: 'S' })).toBe('7S');
+  });
+});
+
+describe('parseCall', () => {
+  it('parses pass', () => {
+    expect(parseCall('P')).toEqual({ type: 'pass' });
+  });
+
+  it('parses double', () => {
+    expect(parseCall('X')).toEqual({ type: 'double' });
+  });
+
+  it('parses redouble', () => {
+    expect(parseCall('XX')).toEqual({ type: 'redouble' });
+  });
+
+  it('parses bids', () => {
+    expect(parseCall('1C')).toEqual({ type: 'bid', level: 1, strain: 'C' });
+    expect(parseCall('3N')).toEqual({ type: 'bid', level: 3, strain: 'N' });
+    expect(parseCall('7S')).toEqual({ type: 'bid', level: 7, strain: 'S' });
+  });
+
+  it('is case-insensitive', () => {
+    expect(parseCall('p')).toEqual({ type: 'pass' });
+    expect(parseCall('x')).toEqual({ type: 'double' });
+    expect(parseCall('xx')).toEqual({ type: 'redouble' });
+  });
+
+  it('throws for invalid call', () => {
+    expect(() => parseCall('Z')).toThrow('Invalid call name');
+    expect(() => parseCall('8C')).toThrow('Invalid call name');
+    expect(() => parseCall('1Z')).toThrow('Invalid call name');
+  });
+
+  it('round-trips with formatCall', () => {
+    const calls: Call[] = [
+      { type: 'pass' },
+      { type: 'double' },
+      { type: 'redouble' },
+      { type: 'bid', level: 1, strain: 'C' },
+      { type: 'bid', level: 4, strain: 'H' },
+      { type: 'bid', level: 7, strain: 'N' },
+    ];
+    for (const call of calls) {
+      expect(parseCall(formatCall(call))).toEqual(call);
+    }
+  });
+});
+
+describe('formatCalls / parseCalls', () => {
+  it('formats an array of calls as comma-separated string', () => {
+    const calls: Call[] = [
+      { type: 'bid', level: 1, strain: 'C' },
+      { type: 'pass' },
+      { type: 'bid', level: 1, strain: 'S' },
+      { type: 'pass' },
+    ];
+    expect(formatCalls(calls)).toBe('1C,P,1S,P');
+  });
+
+  it('parses a comma-separated string', () => {
+    const calls = parseCalls('1C,P,1S,P,2S,P,3S,P,P,P');
+    expect(calls).toHaveLength(10);
+    expect(calls[0]).toEqual({ type: 'bid', level: 1, strain: 'C' });
+    expect(calls[1]).toEqual({ type: 'pass' });
+    expect(calls[4]).toEqual({ type: 'bid', level: 2, strain: 'S' });
+  });
+
+  it('returns empty array for empty string', () => {
+    expect(parseCalls('')).toEqual([]);
+  });
+
+  it('handles doubles and redoubles', () => {
+    const calls = parseCalls('1N,X,XX,P,P,P');
+    expect(calls).toEqual([
+      { type: 'bid', level: 1, strain: 'N' },
+      { type: 'double' },
+      { type: 'redouble' },
+      { type: 'pass' },
+      { type: 'pass' },
+      { type: 'pass' },
+    ]);
+  });
+});
+
+describe('encodeDeal', () => {
+  it('encodes MOCK_DEAL to expected hex string', () => {
+    expect(encodeDeal(MOCK_DEAL)).toBe('60357eabf0365f3a54383ea650');
+  });
+
+  it('produces a 26-character hex string', () => {
+    const hex = encodeDeal(MOCK_DEAL);
+    expect(hex).toHaveLength(26);
+    expect(hex).toMatch(/^[0-9a-f]{26}$/);
+  });
+});
+
+describe('decodeDeal', () => {
+  it('decodes the MOCK_DEAL hex back to the same deal', () => {
+    const decoded = decodeDeal('60357eabf0365f3a54383ea650');
+    expect(decoded.north.cards).toHaveLength(13);
+    expect(decoded.east.cards).toHaveLength(13);
+    expect(decoded.south.cards).toHaveLength(13);
+    expect(decoded.west.cards).toHaveLength(13);
+  });
+
+  it('round-trips with encodeDeal', () => {
+    const hex = encodeDeal(MOCK_DEAL);
+    const decoded = decodeDeal(hex);
+    const rehex = encodeDeal(decoded);
+    expect(rehex).toBe(hex);
+  });
+
+  it('produces cards that match the original deal', () => {
+    const hex = encodeDeal(MOCK_DEAL);
+    const decoded = decodeDeal(hex);
+
+    const toSet = (hand: { cards: Card[] }) =>
+      new Set(hand.cards.map(c => `${c.suit}${c.rank}`));
+
+    expect(toSet(decoded.north)).toEqual(toSet(MOCK_DEAL.north));
+    expect(toSet(decoded.east)).toEqual(toSet(MOCK_DEAL.east));
+    expect(toSet(decoded.south)).toEqual(toSet(MOCK_DEAL.south));
+    expect(toSet(decoded.west)).toEqual(toSet(MOCK_DEAL.west));
+  });
+
+  it('throws for invalid hex length', () => {
+    expect(() => decodeDeal('abc')).toThrow('expected 26 hex chars');
+  });
+
+  it('throws for invalid hex characters', () => {
+    expect(() => decodeDeal('zzzzzzzzzzzzzzzzzzzzzzzzzz')).toThrow('Invalid hex character');
+  });
+});
+
+describe('encodeBoardIdentifier', () => {
+  it('encodes board number and deal', () => {
+    const id = encodeBoardIdentifier(15, MOCK_DEAL);
+    expect(id).toBe('15-60357eabf0365f3a54383ea650');
+  });
+
+  it('includes call history when provided', () => {
+    const calls: Call[] = [
+      { type: 'bid', level: 1, strain: 'N' },
+      { type: 'pass' },
+      { type: 'bid', level: 2, strain: 'C' },
+      { type: 'pass' },
+    ];
+    const id = encodeBoardIdentifier(15, MOCK_DEAL, calls);
+    expect(id).toBe('15-60357eabf0365f3a54383ea650:1N,P,2C,P');
+  });
+});
+
+describe('decodeBoardIdentifier', () => {
+  it('parses board number and deal', () => {
+    const result = decodeBoardIdentifier('15-60357eabf0365f3a54383ea650');
+    expect(result.boardNumber).toBe(15);
+    expect(result.calls).toEqual([]);
+
+    const toSet = (hand: { cards: Card[] }) =>
+      new Set(hand.cards.map(c => `${c.suit}${c.rank}`));
+    expect(toSet(result.deal.north)).toEqual(toSet(MOCK_DEAL.north));
+  });
+
+  it('parses call history', () => {
+    const result = decodeBoardIdentifier('15-60357eabf0365f3a54383ea650:1C,P,1S,P,2S,P,3S,P,P,P');
+    expect(result.boardNumber).toBe(15);
+    expect(result.calls).toHaveLength(10);
+    expect(result.calls[0]).toEqual({ type: 'bid', level: 1, strain: 'C' });
+    expect(result.calls[9]).toEqual({ type: 'pass' });
+  });
+
+  it('round-trips with encodeBoardIdentifier', () => {
+    const calls: Call[] = [
+      { type: 'bid', level: 1, strain: 'C' },
+      { type: 'pass' },
+    ];
+    const original = encodeBoardIdentifier(8, MOCK_DEAL, calls);
+    const decoded = decodeBoardIdentifier(original);
+    expect(decoded.boardNumber).toBe(8);
+    expect(decoded.calls).toEqual(calls);
+    const reencoded = encodeBoardIdentifier(decoded.boardNumber, decoded.deal, decoded.calls);
+    expect(reencoded).toBe(original);
+  });
+
+  it('throws for missing dash', () => {
+    expect(() => decodeBoardIdentifier('abc')).toThrow('missing dash');
+  });
+
+  it('throws for non-numeric board number', () => {
+    expect(() => decodeBoardIdentifier('xx-60357eabf0365f3a54383ea650')).toThrow('not a number');
+  });
+});

--- a/src/bridge/board-identifier.ts
+++ b/src/bridge/board-identifier.ts
@@ -1,0 +1,229 @@
+import type { Call, Card, Deal, Hand, Position, StrainName, SuitName, RankName, Vulnerability } from './types';
+
+// Encoding order matches saycbridge: Clubs=0, Diamonds=1, Hearts=2, Spades=3
+const ENCODING_SUITS: SuitName[] = ['C', 'D', 'H', 'S'];
+
+// Encoding order: 2=0, 3=1, ..., T=8, J=9, Q=10, K=11, A=12
+const ENCODING_RANKS: RankName[] = ['2', '3', '4', '5', '6', '7', '8', '9', 'T', 'J', 'Q', 'K', 'A'];
+
+const HEX_CHARS = '0123456789abcdef';
+
+// Position index for encoding: N=0, E=1, S=2, W=3
+const POSITION_INDEX: Record<Position, number> = { N: 0, E: 1, S: 2, W: 3 };
+const INDEX_POSITION: Position[] = ['N', 'E', 'S', 'W'];
+
+/**
+ * Maps a card to its unique identifier (0-51).
+ * suitIndex * 13 + rankIndex
+ */
+export function cardId(card: Card): number {
+  const suitIndex = ENCODING_SUITS.indexOf(card.suit);
+  const rankIndex = ENCODING_RANKS.indexOf(card.rank);
+  return suitIndex * 13 + rankIndex;
+}
+
+/**
+ * Maps a card identifier (0-51) back to a Card.
+ */
+export function cardFromId(id: number): Card {
+  const suitIndex = Math.floor(id / 13);
+  const rankIndex = id % 13;
+  return { suit: ENCODING_SUITS[suitIndex], rank: ENCODING_RANKS[rankIndex] };
+}
+
+/**
+ * Returns the dealer position for a given board number (1-16).
+ * Formula from saycbridge: (boardNumber + 3) % 4
+ */
+export function dealerForBoard(boardNumber: number): Position {
+  return INDEX_POSITION[(boardNumber + 3) % 4];
+}
+
+// Standard duplicate bridge vulnerability by board number (mod 16).
+// Source: saycbridge callhistory.py Vulnerability.from_board_number
+const VULNERABILITY_TABLE: Vulnerability[] = [
+  'EW',   // 0 (board 16)
+  'None', // 1
+  'NS',   // 2
+  'EW',   // 3
+  'Both', // 4
+  'NS',   // 5
+  'EW',   // 6
+  'Both', // 7
+  'None', // 8
+  'EW',   // 9
+  'Both', // 10
+  'None', // 11
+  'NS',   // 12
+  'Both', // 13
+  'None', // 14
+  'NS',   // 15
+];
+
+/**
+ * Returns the vulnerability for a given board number (1-16).
+ */
+export function vulnerabilityForBoard(boardNumber: number): Vulnerability {
+  return VULNERABILITY_TABLE[boardNumber % 16];
+}
+
+/**
+ * Encodes a Deal into a 26-character hex string.
+ *
+ * Each card (0-51) is assigned to a position (0-3).
+ * Pairs of position indices are packed into hex digits: hex = posA * 4 + posB.
+ */
+export function encodeDeal(deal: Deal): string {
+  const positionForCard = new Array<number>(52);
+
+  const hands: [Position, Hand][] = [
+    ['N', deal.north],
+    ['E', deal.east],
+    ['S', deal.south],
+    ['W', deal.west],
+  ];
+
+  for (const [position, hand] of hands) {
+    const posIndex = POSITION_INDEX[position];
+    for (const card of hand.cards) {
+      positionForCard[cardId(card)] = posIndex;
+    }
+  }
+
+  let identifier = '';
+  for (let offset = 0; offset < 26; offset++) {
+    const hexIndex = positionForCard[offset * 2] * 4 + positionForCard[offset * 2 + 1];
+    identifier += HEX_CHARS[hexIndex];
+  }
+  return identifier;
+}
+
+/**
+ * Decodes a 26-character hex string into a Deal.
+ */
+export function decodeDeal(hex: string): Deal {
+  if (hex.length !== 26) {
+    throw new Error(`Invalid deal identifier: expected 26 hex chars, got ${hex.length}`);
+  }
+
+  const hands: Card[][] = [[], [], [], []]; // N, E, S, W
+
+  for (let charIndex = 0; charIndex < 26; charIndex++) {
+    const hexChar = hex[charIndex];
+    const hexIndex = HEX_CHARS.indexOf(hexChar);
+    if (hexIndex === -1) {
+      throw new Error(`Invalid hex character '${hexChar}' at position ${charIndex}`);
+    }
+
+    const highHandIndex = Math.floor(hexIndex / 4);
+    const lowHandIndex = hexIndex % 4;
+
+    hands[highHandIndex].push(cardFromId(charIndex * 2));
+    hands[lowHandIndex].push(cardFromId(charIndex * 2 + 1));
+  }
+
+  return {
+    north: { cards: hands[0] },
+    east: { cards: hands[1] },
+    south: { cards: hands[2] },
+    west: { cards: hands[3] },
+  };
+}
+
+/**
+ * Formats a Call as a short string: "P", "X", "XX", "1C", "2N", etc.
+ * Matches saycbridge call name format.
+ */
+export function formatCall(call: Call): string {
+  switch (call.type) {
+    case 'pass': return 'P';
+    case 'double': return 'X';
+    case 'redouble': return 'XX';
+    case 'bid': return `${call.level}${call.strain}`;
+  }
+}
+
+/**
+ * Parses a short call string ("P", "X", "XX", "1C", "2N", etc.) into a Call.
+ */
+export function parseCall(name: string): Call {
+  const upper = name.toUpperCase();
+  if (upper === 'P') return { type: 'pass' };
+  if (upper === 'X') return { type: 'double' };
+  if (upper === 'XX') return { type: 'redouble' };
+  if (upper.length === 2) {
+    const level = parseInt(upper[0], 10);
+    const strain = upper[1] as StrainName;
+    if (level >= 1 && level <= 7 && 'CDHSN'.includes(strain)) {
+      return { type: 'bid', level, strain };
+    }
+  }
+  throw new Error(`Invalid call name: '${name}'`);
+}
+
+/**
+ * Formats an array of Calls as a comma-separated string.
+ */
+export function formatCalls(calls: Call[]): string {
+  return calls.map(formatCall).join(',');
+}
+
+/**
+ * Parses a comma-separated call string into an array of Calls.
+ */
+export function parseCalls(callsString: string): Call[] {
+  if (!callsString) return [];
+  return callsString.split(',').map(parseCall);
+}
+
+/**
+ * Encodes a full board identifier string: "boardNumber-dealHex[:callHistory]"
+ */
+export function encodeBoardIdentifier(
+  boardNumber: number,
+  deal: Deal,
+  calls?: Call[],
+): string {
+  let identifier = `${boardNumber}-${encodeDeal(deal)}`;
+  if (calls && calls.length > 0) {
+    identifier += `:${formatCalls(calls)}`;
+  }
+  return identifier;
+}
+
+export interface BoardIdentifier {
+  boardNumber: number;
+  deal: Deal;
+  calls: Call[];
+}
+
+/**
+ * Parses a full board identifier string: "boardNumber-dealHex[:callHistory]"
+ */
+export function decodeBoardIdentifier(identifier: string): BoardIdentifier {
+  const dashIndex = identifier.indexOf('-');
+  if (dashIndex === -1) {
+    throw new Error('Invalid board identifier: missing dash separator');
+  }
+
+  const boardNumber = parseInt(identifier.substring(0, dashIndex), 10);
+  if (isNaN(boardNumber)) {
+    throw new Error('Invalid board identifier: board number is not a number');
+  }
+
+  const rest = identifier.substring(dashIndex + 1);
+  const colonIndex = rest.indexOf(':');
+
+  let dealHex: string;
+  let calls: Call[] = [];
+
+  if (colonIndex === -1) {
+    dealHex = rest;
+  } else {
+    dealHex = rest.substring(0, colonIndex);
+    calls = parseCalls(rest.substring(colonIndex + 1));
+  }
+
+  const deal = decodeDeal(dealHex);
+  return { boardNumber, deal, calls };
+}

--- a/src/bridge/types.ts
+++ b/src/bridge/types.ts
@@ -97,6 +97,8 @@ export interface CallInterpretation {
   description?: string;
 }
 
+export type Vulnerability = 'None' | 'NS' | 'EW' | 'Both';
+
 const HCP_VALUES: Partial<Record<RankName, number>> = { A: 4, K: 3, Q: 2, J: 1 };
 
 export function highCardPoints(hand: Hand): number {


### PR DESCRIPTION
## Summary
- Adds `src/bridge/board-identifier.ts` implementing the saycbridge board identifier format (e.g. `15-60357eabf0365f3a54383ea650:1C,P,1S,P`)
- Encodes/decodes deals as 26-char hex strings, maps board numbers to dealer/vulnerability, and parses call history strings into typed `Call[]` objects
- Adds `Vulnerability` type to `types.ts`

## Test plan
- [x] 45 tests passing (40 new in `board-identifier.test.ts`)
- [x] Round-trip tests for card IDs, deals, and full board identifiers
- [x] Known-value test against hand-computed hex for `MOCK_DEAL`
- [x] Call parsing/formatting including pass, double, redouble, and bids
- [x] Error handling for invalid inputs