### PR TITLE
Redirect / to /bid/<auto-generated-board-id>

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,20 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
-import { HomePage } from './pages/HomePage';
-import { ExplorePage } from './pages/ExplorePage';
-import { PracticePage } from './pages/PracticePage';
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { ExplorePage } from "./pages/ExplorePage";
+import { PracticePage } from "./pages/PracticePage";
+import { generateBoardId } from "./bridge";
+
+function RedirectToNewBoard() {
+  const { id } = generateBoardId();
+  return <Navigate to={`/bid/${id}`} replace />;
+}
 
 export default function App() {
   return (
     <BrowserRouter>
       <Routes>
-        <Route path="/" element={<HomePage />} />
+        <Route path="/" element={<RedirectToNewBoard />} />
+        <Route path="/bid/:boardId" element={<PracticePage />} />
         <Route path="/explore" element={<ExplorePage />} />
-        <Route path="/practice" element={<PracticePage />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/bridge/__tests__/identifier.test.ts
+++ b/src/bridge/__tests__/identifier.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import {
+  encodeDeal,
+  decodeDeal,
+  dealerFromBoardNumber,
+  generateBoardId,
+  parseBoardId,
+} from "../identifier";
+import { randomDeal, MOCK_DEAL } from "../mock";
+
+describe("encodeDeal / decodeDeal", () => {
+  it("roundtrips a random deal", () => {
+    const deal = randomDeal();
+    const hex = encodeDeal(deal);
+    expect(hex).toHaveLength(26);
+    expect(hex).toMatch(/^[0-9a-f]{26}$/);
+
+    const decoded = decodeDeal(hex);
+    expect(decoded).not.toBeNull();
+    // Each hand should have 13 cards
+    expect(decoded!.north.cards).toHaveLength(13);
+    expect(decoded!.east.cards).toHaveLength(13);
+    expect(decoded!.south.cards).toHaveLength(13);
+    expect(decoded!.west.cards).toHaveLength(13);
+
+    // Re-encoding should produce the same hex
+    expect(encodeDeal(decoded!)).toBe(hex);
+  });
+
+  it("roundtrips MOCK_DEAL", () => {
+    const hex = encodeDeal(MOCK_DEAL);
+    const decoded = decodeDeal(hex);
+    expect(decoded).not.toBeNull();
+    expect(encodeDeal(decoded!)).toBe(hex);
+  });
+
+  it("preserves all 52 cards", () => {
+    const deal = randomDeal();
+    const decoded = decodeDeal(encodeDeal(deal))!;
+    const allCards = [
+      ...decoded.north.cards,
+      ...decoded.east.cards,
+      ...decoded.south.cards,
+      ...decoded.west.cards,
+    ];
+    expect(allCards).toHaveLength(52);
+    const unique = new Set(allCards.map((c) => `${c.suit}${c.rank}`));
+    expect(unique.size).toBe(52);
+  });
+});
+
+describe("decodeDeal", () => {
+  it("returns null for invalid length", () => {
+    expect(decodeDeal("abc")).toBeNull();
+    expect(decodeDeal("")).toBeNull();
+  });
+
+  it("returns null for invalid hex characters", () => {
+    expect(decodeDeal("zzzzzzzzzzzzzzzzzzzzzzzzzz")).toBeNull();
+  });
+});
+
+describe("dealerFromBoardNumber", () => {
+  it("returns correct dealers for boards 1-4", () => {
+    expect(dealerFromBoardNumber(1)).toBe("N");
+    expect(dealerFromBoardNumber(2)).toBe("E");
+    expect(dealerFromBoardNumber(3)).toBe("S");
+    expect(dealerFromBoardNumber(4)).toBe("W");
+  });
+
+  it("cycles for boards 5-8", () => {
+    expect(dealerFromBoardNumber(5)).toBe("N");
+    expect(dealerFromBoardNumber(6)).toBe("E");
+    expect(dealerFromBoardNumber(7)).toBe("S");
+    expect(dealerFromBoardNumber(8)).toBe("W");
+  });
+});
+
+describe("generateBoardId", () => {
+  it("returns a valid board number, deal, and id", () => {
+    const { boardNumber, deal, id } = generateBoardId();
+    expect(boardNumber).toBeGreaterThanOrEqual(1);
+    expect(boardNumber).toBeLessThanOrEqual(16);
+    expect(deal.north.cards).toHaveLength(13);
+    expect(id).toMatch(/^\d{1,2}-[0-9a-f]{26}$/);
+  });
+
+  it("id encodes the returned deal", () => {
+    const { deal, id } = generateBoardId();
+    const parsed = parseBoardId(id);
+    expect(parsed).not.toBeNull();
+    expect(encodeDeal(parsed!.deal)).toBe(encodeDeal(deal));
+  });
+});
+
+describe("parseBoardId", () => {
+  it("parses a valid board id", () => {
+    const { id, boardNumber } = generateBoardId();
+    const parsed = parseBoardId(id);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.boardNumber).toBe(boardNumber);
+    expect(parsed!.dealer).toBe(dealerFromBoardNumber(boardNumber));
+    expect(parsed!.deal.north.cards).toHaveLength(13);
+  });
+
+  it("returns null for invalid ids", () => {
+    expect(parseBoardId("")).toBeNull();
+    expect(parseBoardId("abc")).toBeNull();
+    expect(parseBoardId("0-0000000000000000000000000")).toBeNull();
+    expect(parseBoardId("17-0000000000000000000000000")).toBeNull();
+  });
+});

--- a/src/bridge/identifier.ts
+++ b/src/bridge/identifier.ts
@@ -1,0 +1,131 @@
+import type { Card, Deal, Hand, Position, SuitName, RankName } from "./types";
+import { randomDeal } from "./mock";
+
+const SUIT_INDEX: Record<SuitName, number> = { C: 0, D: 1, H: 2, S: 3 };
+const RANK_INDEX: Record<RankName, number> = {
+  "2": 0,
+  "3": 1,
+  "4": 2,
+  "5": 3,
+  "6": 4,
+  "7": 5,
+  "8": 6,
+  "9": 7,
+  T: 8,
+  J: 9,
+  Q: 10,
+  K: 11,
+  A: 12,
+};
+
+const SUITS_BY_INDEX: SuitName[] = ["C", "D", "H", "S"];
+const RANKS_BY_INDEX: RankName[] = [
+  "2",
+  "3",
+  "4",
+  "5",
+  "6",
+  "7",
+  "8",
+  "9",
+  "T",
+  "J",
+  "Q",
+  "K",
+  "A",
+];
+const POSITIONS_BY_INDEX: Position[] = ["N", "E", "S", "W"];
+const HEX_CHARS = "0123456789abcdef";
+
+function cardId(card: Card): number {
+  return SUIT_INDEX[card.suit] * 13 + RANK_INDEX[card.rank];
+}
+
+function cardFromId(id: number): Card {
+  return {
+    suit: SUITS_BY_INDEX[Math.floor(id / 13)],
+    rank: RANKS_BY_INDEX[id % 13],
+  };
+}
+
+/** Encode a Deal to a 26-character hex string (saycbridge format). */
+export function encodeDeal(deal: Deal): string {
+  const positionForCard = new Uint8Array(52);
+  const hands: [Position, Hand][] = [
+    ["N", deal.north],
+    ["E", deal.east],
+    ["S", deal.south],
+    ["W", deal.west],
+  ];
+  for (const [pos, hand] of hands) {
+    const posIdx = POSITIONS_BY_INDEX.indexOf(pos);
+    for (const card of hand.cards) {
+      positionForCard[cardId(card)] = posIdx;
+    }
+  }
+
+  let hex = "";
+  for (let i = 0; i < 26; i++) {
+    const high = positionForCard[i * 2];
+    const low = positionForCard[i * 2 + 1];
+    hex += HEX_CHARS[high * 4 + low];
+  }
+  return hex;
+}
+
+/** Decode a 26-character hex string to a Deal. Returns null if invalid. */
+export function decodeDeal(hex: string): Deal | null {
+  if (hex.length !== 26) return null;
+
+  const hands: Card[][] = [[], [], [], []];
+  for (let charIdx = 0; charIdx < 26; charIdx++) {
+    const hexVal = HEX_CHARS.indexOf(hex[charIdx].toLowerCase());
+    if (hexVal < 0) return null;
+
+    const highPosIdx = Math.floor(hexVal / 4);
+    const lowPosIdx = hexVal % 4;
+
+    hands[highPosIdx].push(cardFromId(charIdx * 2));
+    hands[lowPosIdx].push(cardFromId(charIdx * 2 + 1));
+  }
+
+  return {
+    north: { cards: hands[0] },
+    east: { cards: hands[1] },
+    south: { cards: hands[2] },
+    west: { cards: hands[3] },
+  };
+}
+
+/** Derive dealer from board number (1-16). */
+export function dealerFromBoardNumber(boardNumber: number): Position {
+  return POSITIONS_BY_INDEX[(boardNumber - 1) % 4];
+}
+
+/** Generate a random board identifier string and its decoded deal. */
+export function generateBoardId(): {
+  boardNumber: number;
+  deal: Deal;
+  id: string;
+} {
+  const boardNumber = Math.floor(Math.random() * 16) + 1;
+  const deal = randomDeal();
+  const id = `${boardNumber}-${encodeDeal(deal)}`;
+  return { boardNumber, deal, id };
+}
+
+/** Parse a board identifier string. Returns null if invalid. */
+export function parseBoardId(
+  id: string,
+): { boardNumber: number; deal: Deal; dealer: Position } | null {
+  const dashIdx = id.indexOf("-");
+  if (dashIdx < 1) return null;
+
+  const boardNumber = parseInt(id.substring(0, dashIdx), 10);
+  if (isNaN(boardNumber) || boardNumber < 1 || boardNumber > 16) return null;
+
+  const deal = decodeDeal(id.substring(dashIdx + 1));
+  if (!deal) return null;
+
+  return { boardNumber, deal, dealer: dealerFromBoardNumber(boardNumber) };
+}

--- a/src/bridge/index.ts
+++ b/src/bridge/index.ts
@@ -1,2 +1,3 @@
-export * from './types';
-export * from './mock';
+export * from "./types";
+export * from "./mock";
+export * from "./identifier";


### PR DESCRIPTION
## Summary
- Loading `/` now generates a random board and redirects to `/bid/<id>` using the saycbridge identifier format (board number + 26-char hex deal encoding)
- Refreshing a `/bid/` URL reloads the same deterministic deal from the URL
- Redeal button navigates to a new `/bid/<id>` URL

## Test plan
- [x] `pnpm test -- --run` passes (16 tests including 11 new identifier tests)
- [x] `pnpm build` succeeds
- [ ] Manual: load `/` → redirects to `/bid/<id>` with a random board
- [ ] Manual: refresh `/bid/<id>` → same deal loads
- [ ] Manual: click redeal → navigates to new `/bid/<new-id>`