### PR TITLE
Wire up robot bidding to WASM engine

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 ```bash
 pnpm dev              # Start Vite dev server
 pnpm build            # Full build: wasm-pack → tsc → vite build
-pnpm wasm:build       # Build Rust WASM crate only
+pnpm wasm:dev         # Build Rust WASM crate (debug, fast)
+pnpm wasm:build       # Build Rust WASM crate (release, optimized)
 pnpm test             # Run Vitest (watches by default)
 pnpm test -- --run    # Run Vitest once without watch mode
 pnpm lint             # ESLint
@@ -23,5 +24,5 @@ Write tests for all code changes. Goal is 90% test coverage.
 ## Gotchas
 
 - **verbatimModuleSyntax** is enabled — use `import type { Foo }` or `import { type Foo, bar }` for type-only imports
-- **WASM is not auto-rebuilt** by the Vite dev server — run `pnpm wasm:build` after Rust changes
+- **WASM is not auto-rebuilt** by the Vite dev server — run `pnpm wasm:dev` after Rust changes
 - **bridge-engine** is currently a stub returning hardcoded data

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "packageManager": "pnpm@10.29.2",
   "scripts": {
     "dev": "vite",
-    "wasm:build": "wasm-pack build crates/bridge-engine --target web --out-dir pkg",
+    "wasm:dev": "wasm-pack build crates/bridge-engine --target web --out-dir pkg --dev",
+    "wasm:build": "wasm-pack build crates/bridge-engine --target web --out-dir pkg --release",
     "build": "pnpm wasm:build && tsc -b && vite build",
     "format:check": "prettier --check .",
     "lint": "eslint .",

--- a/src/bridge/__tests__/auction.test.ts
+++ b/src/bridge/__tests__/auction.test.ts
@@ -1,15 +1,28 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   currentPlayer,
   isAuctionComplete,
   lastBidCall,
-  addRobotPasses,
+  callToString,
+  addRobotBids,
 } from "../auction";
 import type { CallHistory, Call } from "../types";
+
+vi.mock("../engine", () => ({
+  getNextBid: vi.fn(),
+}));
+
+import { getNextBid } from "../engine";
+const mockGetNextBid = vi.mocked(getNextBid);
 
 const pass: Call = { type: "pass" };
 const oneClub: Call = { type: "bid", level: 1, strain: "C" };
 const oneHeart: Call = { type: "bid", level: 1, strain: "H" };
+const oneNT: Call = { type: "bid", level: 1, strain: "N" };
+
+beforeEach(() => {
+  mockGetNextBid.mockReset();
+});
 
 describe("currentPlayer", () => {
   it("returns dealer when no calls have been made", () => {
@@ -86,55 +99,92 @@ describe("lastBidCall", () => {
   });
 });
 
-describe("addRobotPasses", () => {
-  it("adds no passes when dealer is the user position", () => {
-    const history: CallHistory = { dealer: "S", calls: [] };
-    const result = addRobotPasses(history, "S");
-    expect(result.calls).toHaveLength(0);
+describe("callToString", () => {
+  it("serializes pass", () => {
+    expect(callToString(pass)).toBe("P");
   });
 
-  it("adds passes until it is the user's turn", () => {
+  it("serializes bids", () => {
+    expect(callToString(oneClub)).toBe("1C");
+    expect(callToString(oneHeart)).toBe("1H");
+    expect(callToString(oneNT)).toBe("1N");
+  });
+
+  it("serializes double and redouble", () => {
+    expect(callToString({ type: "double" })).toBe("X");
+    expect(callToString({ type: "redouble" })).toBe("XX");
+  });
+});
+
+describe("addRobotBids", () => {
+  const boardId = "1-00000000000000000000000000";
+
+  it("adds no bids when dealer is the user position", async () => {
+    const history: CallHistory = { dealer: "S", calls: [] };
+    const result = await addRobotBids(history, "S", boardId);
+    expect(result.calls).toHaveLength(0);
+    expect(mockGetNextBid).not.toHaveBeenCalled();
+  });
+
+  it("calls engine for each robot turn until user's turn", async () => {
+    mockGetNextBid.mockResolvedValue(pass);
     const history: CallHistory = { dealer: "N", calls: [] };
-    const result = addRobotPasses(history, "S");
+    const result = await addRobotBids(history, "S", boardId);
     // N passes, E passes → now S's turn
     expect(result.calls).toHaveLength(2);
     expect(result.calls.every((c) => c.type === "pass")).toBe(true);
     expect(currentPlayer(result)).toBe("S");
+    expect(mockGetNextBid).toHaveBeenCalledTimes(2);
   });
 
-  it("wraps around correctly when dealer is West and user is South", () => {
+  it("passes the correct identifier with call history", async () => {
+    mockGetNextBid.mockResolvedValue(pass);
+    const history: CallHistory = { dealer: "E", calls: [] };
+    await addRobotBids(history, "S", boardId);
+    // First call: no calls yet
+    expect(mockGetNextBid).toHaveBeenCalledWith(boardId);
+    // Second call would not happen since E passes then it's S's turn
+    expect(mockGetNextBid).toHaveBeenCalledTimes(1);
+  });
+
+  it("builds identifier with accumulated calls", async () => {
+    mockGetNextBid.mockResolvedValue(pass);
     const history: CallHistory = { dealer: "W", calls: [] };
-    const result = addRobotPasses(history, "S");
-    // W passes, N passes, E passes → now S's turn
-    expect(result.calls).toHaveLength(3);
-    expect(currentPlayer(result)).toBe("S");
+    await addRobotBids(history, "S", boardId);
+    // W, N, E all need to bid before S
+    expect(mockGetNextBid).toHaveBeenCalledTimes(3);
+    // Third call should include previous two passes
+    expect(mockGetNextBid).toHaveBeenNthCalledWith(3, `${boardId}:P,P`);
   });
 
-  it("adds passes after user bid until user's turn again", () => {
+  it("uses real bids from the engine", async () => {
+    mockGetNextBid.mockResolvedValueOnce(oneNT); // E opens 1NT
+    const history: CallHistory = { dealer: "E", calls: [] };
+    const result = await addRobotBids(history, "S", boardId);
+    // E bids 1NT → S's turn
+    expect(result.calls).toHaveLength(1);
+    expect(result.calls[0]).toEqual(oneNT);
+  });
+
+  it("completes auction when all robots pass out", async () => {
+    mockGetNextBid.mockResolvedValue(pass);
+    // Dealer is S (user), user passes. Robots should all pass → auction done.
+    const history: CallHistory = { dealer: "S", calls: [pass] };
+    const result = await addRobotBids(history, "S", boardId);
+    expect(result.calls).toHaveLength(4);
+    expect(isAuctionComplete(result)).toBe(true);
+  });
+
+  it("adds robot bids after user bid until user's turn again", async () => {
+    mockGetNextBid.mockResolvedValue(pass);
     // Dealer is N, user is S. N and E already passed, user bid 1C.
     const history: CallHistory = {
       dealer: "N",
       calls: [pass, pass, oneClub],
     };
     // After user's 1C: W passes, N passes, E passes → S's turn
-    const result = addRobotPasses(history, "S");
+    const result = await addRobotBids(history, "S", boardId);
     expect(result.calls).toHaveLength(6);
-    expect(currentPlayer(result)).toBe("S");
-  });
-
-  it("completes auction when all robots pass out", () => {
-    // Dealer is S (user), user passes. Robots should all pass → auction done.
-    const history: CallHistory = { dealer: "S", calls: [pass] };
-    const result = addRobotPasses(history, "S");
-    expect(result.calls).toHaveLength(4);
-    expect(isAuctionComplete(result)).toBe(true);
-  });
-
-  it("works with East as dealer and user as South", () => {
-    const history: CallHistory = { dealer: "E", calls: [] };
-    const result = addRobotPasses(history, "S");
-    // E passes → S's turn
-    expect(result.calls).toHaveLength(1);
     expect(currentPlayer(result)).toBe("S");
   });
 });

--- a/src/bridge/auction.ts
+++ b/src/bridge/auction.ts
@@ -1,4 +1,5 @@
 import type { Call, CallHistory, Position } from "./types";
+import { getNextBid } from "./engine";
 
 const POSITION_ORDER: Position[] = ["N", "E", "S", "W"];
 
@@ -20,14 +21,31 @@ export function lastBidCall(history: CallHistory): Call | undefined {
   return [...history.calls].reverse().find((c) => c.type === "bid");
 }
 
-/** Add robot passes until it's the given position's turn or the auction completes. */
-export function addRobotPasses(
+/** Serialize a Call to the short string format the Rust engine uses. */
+export function callToString(call: Call): string {
+  if (call.type === "pass") return "P";
+  if (call.type === "double") return "X";
+  if (call.type === "redouble") return "XX";
+  return `${call.level}${call.strain}`;
+}
+
+/** Build the identifier string for the Rust engine: "<board>-<hex>:<calls>". */
+function buildIdentifier(boardId: string, calls: Call[]): string {
+  if (calls.length === 0) return boardId;
+  return `${boardId}:${calls.map(callToString).join(",")}`;
+}
+
+/** Add robot bids (via WASM engine) until it's the user's turn or the auction completes. */
+export async function addRobotBids(
   history: CallHistory,
   userPosition: Position,
-): CallHistory {
+  boardId: string,
+): Promise<CallHistory> {
   let h = history;
   while (!isAuctionComplete(h) && currentPlayer(h) !== userPosition) {
-    h = { ...h, calls: [...h.calls, { type: "pass" as const }] };
+    const identifier = buildIdentifier(boardId, h.calls);
+    const call = await getNextBid(identifier);
+    h = { ...h, calls: [...h.calls, call] };
   }
   return h;
 }

--- a/src/bridge/bridge-engine.d.ts
+++ b/src/bridge/bridge-engine.d.ts
@@ -7,4 +7,5 @@ declare module "../../crates/bridge-engine/pkg/bridge_engine" {
     calls_string: string,
     dealer: string,
   ): unknown;
+  export function get_next_bid(identifier: string): string;
 }

--- a/src/pages/ExplorePage.tsx
+++ b/src/pages/ExplorePage.tsx
@@ -2,16 +2,9 @@ import { useState, useEffect } from "react";
 import { NavBar } from "../components/NavBar";
 import { CallTable } from "../components/CallTable";
 import { CallMenu } from "../components/CallMenu";
-import type { CallHistory, CallInterpretation, Call } from "../bridge";
+import type { CallHistory, CallInterpretation } from "../bridge";
 import { getInterpretations } from "../bridge/engine";
-
-function callToString(call: Call): string {
-  if (call.type === "pass") return "Pass";
-  if (call.type === "double") return "X";
-  if (call.type === "redouble") return "XX";
-  const strainMap = { C: "C", D: "D", H: "H", S: "S", N: "N" } as const;
-  return `${call.level}${strainMap[call.strain!]}`;
-}
+import { callToString } from "../bridge/auction";
 
 export function ExplorePage() {
   const [history, setHistory] = useState<CallHistory>({

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,4 +6,10 @@ import topLevelAwait from "vite-plugin-top-level-await";
 
 export default defineConfig({
   plugins: [wasm(), topLevelAwait(), react(), tailwindcss()],
+  server: {
+    watch: {
+      // Watch the wasm-pack output directory (gitignored, so Vite may skip it)
+      ignored: ["!**/crates/*/pkg/**"],
+    },
+  },
 });


### PR DESCRIPTION
## Summary
- Replace `addRobotPasses` (which blindly passed for all robots) with async `addRobotBids` that calls `get_next_bid` from the WASM bridge-engine
- Add `getNextBid` TS wrapper in `engine.ts` and shared `callToString` helper in `auction.ts`
- Update `PracticePage` to use `useEffect` for async robot bidding with loading state
- Add `wasm:dev` script for fast debug WASM builds and configure Vite to watch the gitignored `crates/*/pkg/` output directory

## Test plan
- [x] All 36 Vitest tests pass (including new async `addRobotBids` tests with mocked engine)
- [x] ESLint and Prettier pass
- [x] Full `pnpm build` succeeds
- [ ] Manual: visit `/bid/8-052d28749f488aeaf05b7cb1dd` and verify East opens 1NT instead of passing