### PR TITLE
ci: Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Install wasm-pack
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install
+
+      - run: pnpm build
+
+      - name: Copy index.html to 404.html for SPA routing
+        run: cp dist/index.html dist/404.html
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ function PracticeRoute() {
 
 export default function App() {
   return (
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <Routes>
         <Route path="/" element={<RedirectToNewBoard />} />
         <Route path="/bid/:boardId" element={<PracticeRoute />} />

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,7 +4,8 @@ import tailwindcss from "@tailwindcss/vite";
 import wasm from "vite-plugin-wasm";
 import topLevelAwait from "vite-plugin-top-level-await";
 
-export default defineConfig({
+export default defineConfig(({ command }) => ({
+  base: command === "build" ? "/yarborough/" : "/",
   plugins: [wasm(), topLevelAwait(), react(), tailwindcss()],
   server: {
     watch: {
@@ -12,4 +13,4 @@ export default defineConfig({
       ignored: ["!**/crates/*/pkg/**"],
     },
   },
-});
+}));


### PR DESCRIPTION
## Summary
- Add deploy workflow that builds (Rust WASM + TypeScript + Vite) and deploys to GitHub Pages on push to main
- Set Vite `base: "/yarborough/"` and React Router `basename` for correct subpath routing
- Copy `index.html` → `404.html` for SPA deep-link support

## Test plan
- [ ] Verify the deploy workflow succeeds on merge
- [ ] Confirm site loads at https://eseidel.github.io/yarborough/
- [ ] Test deep links (e.g. `/yarborough/bid/<id>`) work via direct navigation